### PR TITLE
Fix messy code in Fedora

### DIFF
--- a/bin/ec2
+++ b/bin/ec2
@@ -32,21 +32,21 @@ while getopts "u:k:c:ixhps" opt; do
       xOpt="-X"
       ;;
     h)
-      echo "\nDisplay and connect easely to your EC2 instance(s)"
+      echo -e "\nDisplay and connect easely to your EC2 instance(s)"
       echo "Usage: $0 [-u user] [-x] [-c \"command\"] [eu|us|us-west-1|region]"
-      echo "\nArguments:"
-      echo "\t-i display instances' details and exit"
-      echo "\t-p use instance's private IPv4"
-      echo "\t-u user"
-      echo "\t-k PEM file"
-      echo "\t-x Export display"
-      echo "\t-s Short view"
-      echo "\t-c \"command (sent by ssh)\""
-      echo "\nAll the arguments are optional, set the default properties in ~/.ec2-default.props"
+      echo -e "\nArguments:"
+      echo -e "\t-i display instances' details and exit"
+      echo -e "\t-p use instance's private IPv4"
+      echo -e "\t-u user"
+      echo -e "\t-k PEM file"
+      echo -e "\t-x Export display"
+      echo -e "\t-s Short view"
+      echo -e "\t-c \"command (sent by ssh)\""
+      echo -e "\nAll the arguments are optional, set the default properties in ~/.ec2-default.props"
       exit 1
       ;;
     \?)
-      echo "\033[1;32mInvalid option: -$OPTARG\033[0m" >&2
+      echo -e "\033[1;32mInvalid option: -$OPTARG\033[0m" >&2
       ;;
   esac
 done
@@ -95,7 +95,7 @@ else
 fi
 
 # Print region info
-echo "\033[33mRegion: $region\033[0m"
+echo -e "\033[33mRegion: $region\033[0m"
 
 # Print info and quit
 if [ "$infoOpt" = "Y" ]
@@ -120,7 +120,7 @@ for i in $name
 do
   index=`expr $index + 1`
   address=`echo "$hostname" | head -$index | tail -1`
-  echo "\033[33m$index. \033[32;1m$i\033[0m ($address)"
+  echo -e "\033[33m$index. \033[32;1m$i\033[0m ($address)"
 done
 unset IFS
 
@@ -142,7 +142,7 @@ do
   done
 
   # Run ssh
-  echo "\033[32mConnecting to $selectedname \033[0m"
-  echo "\033[33mssh -i $key $xOpt $user@$selectedhost\033[0m"
+  echo -e "\033[32mConnecting to $selectedname \033[0m"
+  echo -e "\033[33mssh -i $key $xOpt $user@$selectedhost\033[0m"
   ssh -o StrictHostKeyChecking=no -i $key $xOpt $user@$selectedhost $commandOpt
 done


### PR DESCRIPTION
Dear Author,

`ec2` is a great tool which can save lots of time.
But there probably be a small issue -- when `ec2` is running on Fedora, we can get messy code from `echo` command in `bin/ec2`.

I'd like to make a pull request to add `-e` to the `echo` command to solve this problem. But when I check the git log, found you didn't merge `-e` change to your repo. 

Tested on Fedora:
```
$ cat /etc/system-release
Fedora release 25 (Twenty Five)
$ echo "\033[32mConnecting to $selectedname \033[0m"
\033[32mConnecting to  \033[0m
$ echo -e "\033[32mConnecting to $selectedname \033[0m"
Connecting to  
```
Tested on RHEL:
```
$ cat /etc/system-release
Red Hat Enterprise Linux Server release 7.4 (Maipo)
$ echo "\033[32mConnecting to $selectedname \033[0m"
\033[32mConnecting to  \033[0m
$ echo -e "\033[32mConnecting to $selectedname \033[0m"
Connecting to  
```
Tested on Ubuntu:
```
$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=16.04
DISTRIB_CODENAME=xenial
DISTRIB_DESCRIPTION="Ubuntu 16.04.2 LTS"
$ echo "\033[32mConnecting to $selectedname \033[0m"
\033[32mConnecting to  \033[0m
$ echo -e "\033[32mConnecting to $selectedname \033[0m"
Connecting to  
```

Thanks,
Charles